### PR TITLE
Add template options and packaging instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# CV/Resume Generator
+
+This Flask application collects resume information via a form and generates a PDF using WeasyPrint.
+
+## Setup
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Run the app
+
+```bash
+python3 app.py
+```
+
+Visit `http://localhost:5000` in your browser to generate a resume.
+
+Select a template from the drop-down menu to switch between the "Classic" and
+"Modern" styles.
+
+## Package the app
+
+To create a zip archive for distribution, run:
+
+```bash
+zip -r resume_app.zip .
+```
+
+Users can unzip the archive, install the requirements, and run the app locally
+with the commands above.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,42 @@
+from flask import Flask, render_template, request, send_file
+from weasyprint import HTML
+import io
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        name = request.form.get('name')
+        email = request.form.get('email')
+        phone = request.form.get('phone')
+        profile = request.form.get('profile')
+        experience = request.form.get('experience')
+        education = request.form.get('education')
+        skills = request.form.get('skills')
+        languages = request.form.get('languages')
+        template_choice = request.form.get('template', 'classic')
+
+        html = render_template(
+            'resume_template.html',
+            name=name,
+            email=email,
+            phone=phone,
+            profile=profile,
+            experience=experience,
+            education=education,
+            skills=skills,
+            languages=languages,
+            template=template_choice
+        )
+        pdf = HTML(string=html).write_pdf()
+        return send_file(
+            io.BytesIO(pdf),
+            mimetype='application/pdf',
+            as_attachment=True,
+            download_name='resume.pdf'
+        )
+    return render_template('form.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+WeasyPrint

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Create Resume</title>
+</head>
+<body>
+    <h1>Resume Generator</h1>
+    <form method="post">
+        <label>Name:<br><input type="text" name="name" required></label><br>
+        <label>Email:<br><input type="email" name="email" required></label><br>
+        <label>Phone:<br><input type="text" name="phone"></label><br>
+        <label>Profile:<br><textarea name="profile"></textarea></label><br>
+        <label>Experience:<br><textarea name="experience"></textarea></label><br>
+        <label>Education:<br><textarea name="education"></textarea></label><br>
+        <label>Skills (comma separated):<br><input type="text" name="skills"></label><br>
+        <label>Languages:<br><input type="text" name="languages"></label><br>
+        <label>Template:<br>
+            <select name="template">
+                <option value="classic">Classic</option>
+                <option value="modern">Modern</option>
+            </select>
+        </label><br>
+        <button type="submit">Generate PDF</button>
+    </form>
+</body>
+</html>

--- a/templates/resume_template.html
+++ b/templates/resume_template.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    {% if template == 'modern' %}
+    <style>
+        body { font-family: Helvetica, sans-serif; background-color: #f4f4f4; }
+        .container { max-width: 800px; margin: auto; background: white; padding: 20px; }
+        h1 { text-align: center; color: #2b6cb0; }
+        .section { margin-bottom: 15px; }
+    </style>
+    {% else %}
+    <style>
+        body { font-family: Times New Roman, serif; }
+        h1 { text-align: center; }
+        .section { margin-bottom: 15px; }
+    </style>
+    {% endif %}
+    <title>Resume</title>
+</head>
+<body>
+    {% if template == 'modern' %}
+    <div class="container">
+        <h1>{{ name }}</h1>
+        <div class="section"><strong>Email:</strong> {{ email }}</div>
+        <div class="section"><strong>Phone:</strong> {{ phone }}</div>
+        <div class="section"><strong>Profile</strong><br>{{ profile }}</div>
+        <div class="section"><strong>Experience</strong><br>{{ experience }}</div>
+        <div class="section"><strong>Education</strong><br>{{ education }}</div>
+        <div class="section"><strong>Skills</strong><br>{{ skills }}</div>
+        <div class="section"><strong>Languages</strong><br>{{ languages }}</div>
+    </div>
+    {% else %}
+    <h1>{{ name }}</h1>
+    <div class="section"><strong>Email:</strong> {{ email }}</div>
+    <div class="section"><strong>Phone:</strong> {{ phone }}</div>
+    <div class="section"><strong>Profile</strong><br>{{ profile }}</div>
+    <div class="section"><strong>Experience</strong><br>{{ experience }}</div>
+    <div class="section"><strong>Education</strong><br>{{ education }}</div>
+    <div class="section"><strong>Skills</strong><br>{{ skills }}</div>
+    <div class="section"><strong>Languages</strong><br>{{ languages }}</div>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add template selection dropdown
- support modern and classic styles in resume template
- pass template to PDF generation
- document how to create a zip package

## Testing
- `python3 --version`


------
https://chatgpt.com/codex/tasks/task_e_684406aea7b8832d8b23e00a39e8d1a0